### PR TITLE
fix(asset-server): drop --headless, init Mesa llvmpipe, wait for Xvfb

### DIFF
--- a/dependencies/godot-asset-optimizer-project/entrypoint.sh
+++ b/dependencies/godot-asset-optimizer-project/entrypoint.sh
@@ -1,13 +1,41 @@
 #!/bin/bash
+set -e
 
 # Godot environment
 export DISPLAY=:99
 export RUST_LOG=warn,dclgodot=info,dclgodot::content::resource_provider=debug
 export NO_COLOR=1
 
-# Start Xvfb
+# Force Mesa to use the software rasterizer (llvmpipe). Without these, Mesa
+# tries pci-id detection against /dev/dri first; in a container without a
+# real GPU node that path can silently fall through to a no-op driver and
+# Godot's opengl3 init fails, dropping the engine into the dummy renderer
+# (texture_2d_get returns null, every SubViewport readback comes back blank,
+# every impostor bake fails with `fail_blank_albedo`).
+export LIBGL_ALWAYS_SOFTWARE=1
+export MESA_LOADER_DRIVER_OVERRIDE=llvmpipe
+
+# Start Xvfb in the background
 /usr/bin/Xvfb -ac :99 -screen 0 1280x1024x24 > /dev/null 2>&1 &
-sleep 1
+
+# Wait for Xvfb to actually accept X connections before launching the Node
+# app (which spawns Godot on demand). A blind `sleep 1` raced — under
+# cold-start container load Xvfb occasionally needed >1s, Godot started
+# without a display, and the opengl3 driver silently fell back to dummy.
+for i in 1 2 3 4 5 6 7 8 9 10; do
+  if xdpyinfo -display :99 >/dev/null 2>&1; then
+    echo "[entrypoint] Xvfb ready after ${i} attempts"
+    break
+  fi
+  sleep 0.5
+  if [ "$i" = "10" ]; then
+    echo "[entrypoint] FATAL: Xvfb never came up on :99"
+    exit 1
+  fi
+done
+
+# Sanity-print the GL renderer so misconfigured deploys are obvious in logs.
+glxinfo -B 2>&1 | grep -E "renderer string|OpenGL version" | head -2 || echo "[entrypoint] WARN: glxinfo failed"
 
 # Start Node.js app (Godot is started/restarted per entity by the asset-server adapter)
 cd /service

--- a/src/adapters/asset-server.ts
+++ b/src/adapters/asset-server.ts
@@ -236,8 +236,14 @@ export function createAssetServerComponent(
       clearGodotLogs()
       addGodotLog(`[${new Date().toISOString()}] Starting Godot asset-server...`)
 
-      // Start new Godot process in background
-      const godotCmd = `/app/decentraland.godot.client.x86_64 --headless --asset-server --asset-server-port ${port}`
+      // Start new Godot process in background.
+      // NO --headless: that wires up the dummy RenderingServer, so the
+      // impostor-bake SubViewport readback returns null pixels and every
+      // octahedral atlas comes back as `fail_blank_albedo` in
+      // [impostor-bake] requested=N baked=0. We need opengl3 + Xvfb (set
+      // up in the container entrypoint with Mesa llvmpipe) so SubViewport
+      // actually rasterizes.
+      const godotCmd = `/app/decentraland.godot.client.x86_64 --rendering-driver opengl3 --audio-driver Dummy --asset-server --asset-server-port ${port}`
       const child = exec(godotCmd)
 
       // Capture stdout


### PR DESCRIPTION
Removes --headless from godot launch in src/adapters/asset-server.ts:240 — it was wiring up the dummy RenderingServer, every impostor SubViewport readback came back null (texture_2d_get null at servers/rendering/dummy/storage/texture_storage.h:106), and every octahedral bake failed with fail_blank_albedo. Switches to --rendering-driver opengl3 --audio-driver Dummy, adds LIBGL_ALWAYS_SOFTWARE=1 + MESA_LOADER_DRIVER_OVERRIDE=llvmpipe + xdpyinfo wait + glxinfo diagnostic in dependencies/godot-asset-optimizer-project/entrypoint.sh. Base image already ships the Mesa DRI runtime so no Dockerfile change needed. v3 unaffected (separate :v3 tag stays on its current SHA).